### PR TITLE
fix null safety bugs

### DIFF
--- a/demo_app/lib/attention_seekers.dart
+++ b/demo_app/lib/attention_seekers.dart
@@ -101,9 +101,10 @@ class AttentionSeekersState extends AnimatorGroupState<AttentionSeekers> {
               child: AnimatorCard(labels[index], colors[index]),
               preferences: AnimationPreferences(autoPlay: playState),
             );
+          default:
+          return  SizedBox();
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+      }),
     );
   }
 }

--- a/demo_app/lib/bouncing_entrances.dart
+++ b/demo_app/lib/bouncing_entrances.dart
@@ -60,8 +60,8 @@ class BouncingEntrancesState extends AnimatorGroupState<BouncingEntrances> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/bouncing_exits.dart
+++ b/demo_app/lib/bouncing_exits.dart
@@ -60,8 +60,8 @@ class BouncingExitsState extends AnimatorGroupState<BouncingExits> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/fading_entrances.dart
+++ b/demo_app/lib/fading_entrances.dart
@@ -88,8 +88,8 @@ class FadingEntrancesState extends AnimatorGroupState<FadingEntrances> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/fading_exits.dart
+++ b/demo_app/lib/fading_exits.dart
@@ -88,8 +88,8 @@ class FadingExitsState extends AnimatorGroupState<FadingExits> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/flippers.dart
+++ b/demo_app/lib/flippers.dart
@@ -60,8 +60,8 @@ class FlippersState extends AnimatorGroupState<Flippers> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/lightspeed.dart
+++ b/demo_app/lib/lightspeed.dart
@@ -39,8 +39,8 @@ class LightSpeedState extends AnimatorGroupState<LightSpeed> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/main.dart
+++ b/demo_app/lib/main.dart
@@ -237,7 +237,7 @@ class _MyHomePageState extends State<MyHomePage> {
           playState: AnimationPlayStates.Forward,
         );
       default:
-        return null;
+       return SizedBox();
     }
   }
 }

--- a/demo_app/lib/rotating_entrances.dart
+++ b/demo_app/lib/rotating_entrances.dart
@@ -60,8 +60,8 @@ class RotatingEntrancesState extends AnimatorGroupState<RotatingEntrances> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/rotating_exits.dart
+++ b/demo_app/lib/rotating_exits.dart
@@ -60,8 +60,8 @@ class RotatingExitsState extends AnimatorGroupState<RotatingExits> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/sliding_entrances.dart
+++ b/demo_app/lib/sliding_entrances.dart
@@ -53,8 +53,8 @@ class SlidingEntrancesState extends AnimatorGroupState<SlidingEntrances> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/sliding_exits.dart
+++ b/demo_app/lib/sliding_exits.dart
@@ -53,8 +53,8 @@ class SlidingExitsState extends AnimatorGroupState<SlidingExits> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/slit_entrances.dart
+++ b/demo_app/lib/slit_entrances.dart
@@ -55,8 +55,8 @@ class SlitEntrancesState extends AnimatorGroupState<SlitEntrances> {
               ),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/slit_exits.dart
+++ b/demo_app/lib/slit_exits.dart
@@ -55,8 +55,8 @@ class SlitExitsState extends AnimatorGroupState<SlitExits> {
               ),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/specials.dart
+++ b/demo_app/lib/specials.dart
@@ -53,8 +53,8 @@ class SpecialsState extends AnimatorGroupState<Specials> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/zooming_entrances.dart
+++ b/demo_app/lib/zooming_entrances.dart
@@ -60,8 +60,8 @@ class ZoomingEntrancesState extends AnimatorGroupState<ZoomingEntrances> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/lib/zooming_exits.dart
+++ b/demo_app/lib/zooming_exits.dart
@@ -60,8 +60,8 @@ class ZoomingExitsState extends AnimatorGroupState<ZoomingExits> {
               preferences: AnimationPreferences(autoPlay: playState),
             );
         }
-        return null;
-      }).where((Widget? w) => w != null).toList() as List<Widget>,
+       return SizedBox();
+      }),
     );
   }
 }

--- a/demo_app/pubspec.lock
+++ b/demo_app/pubspec.lock
@@ -65,9 +65,9 @@ packages:
   flutter_animator:
     dependency: "direct main"
     description:
-      name: flutter_animator
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: ".."
+      relative: true
+    source: path
     version: "3.1.0"
   flutter_test:
     dependency: "direct dev"

--- a/demo_app/pubspec.lock
+++ b/demo_app/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -65,10 +65,10 @@ packages:
   flutter_animator:
     dependency: "direct main"
     description:
-      path: ".."
-      relative: true
-    source: path
-    version: "2.1.0"
+      name: flutter_animator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,21 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,55 +106,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/demo_app/pubspec.yaml
+++ b/demo_app/pubspec.yaml
@@ -3,13 +3,13 @@ description: Provides examples using the Animated Widgets from the Animator pack
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^0.1.2
-  flutter_animator: ^2.1.0
+  flutter_animator: ^3.1.0
 
 dev_dependencies:
   flutter_test:

--- a/demo_app/pubspec.yaml
+++ b/demo_app/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^0.1.2
-  flutter_animator: ^3.1.0
+  flutter_animator:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class ExampleApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key}) : super(key: key);
+  MyHomePage({Key? key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -52,7 +52,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(padding: EdgeInsets.only(top: 20)),
             TextButton(
               onPressed: () {
-                crossFadeAnimation.currentState.cross();
+                crossFadeAnimation.currentState!.cross();
               },
               child: Text(
                 'Cross Animate',
@@ -69,7 +69,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(padding: EdgeInsets.only(top: 20)),
             TextButton(
               onPressed: () {
-                basicAnimation.currentState.forward();
+                basicAnimation.currentState!.forward();
               },
               child: Text(
                 'Animate Bounce',
@@ -89,11 +89,11 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(padding: EdgeInsets.only(top: 20)),
             TextButton(
               onPressed: () {
-                if (inOutAnimation.currentState.status !=
+                if (inOutAnimation.currentState!.status !=
                     InOutAnimationStatus.Out) {
-                  inOutAnimation.currentState.animateOut();
+                  inOutAnimation.currentState!.animateOut();
                 } else {
-                  inOutAnimation.currentState.animateIn();
+                  inOutAnimation.currentState!.animateIn();
                 }
               },
               child: Text(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -65,10 +65,10 @@ packages:
   flutter_animator:
     dependency: "direct main"
     description:
-      name: flutter_animator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
+      path: ".."
+      relative: true
+    source: path
+    version: "3.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,13 +3,14 @@ description: Provides examples using the Animated Widgets from the Animator pack
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^0.1.2
-  flutter_animator: ^2.1.0
+  flutter_animator: 
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/lib/animation/tween_list.dart
+++ b/lib/animation/tween_list.dart
@@ -12,7 +12,7 @@ import '../utils/pair.dart';
 ///value-blends.
 ///Please note that although Matrix4 tweens are supported, they tend to be a bit
 ///slower, due to the Matrix decomposition
-class TweenList<T extends dynamic> extends Tween<T?> {
+class TweenList<T extends dynamic> extends Tween<T> {
   ///Holds all the percentages.
   late List<TweenPercentage<T>> _values;
 
@@ -47,7 +47,7 @@ class TweenList<T extends dynamic> extends Tween<T?> {
 
   ///Returns a current animated value at the supplied theta.
   @override
-  T? transform(double t) {
+  T transform(double t) {
     double beginT =
         offset.inMilliseconds.toDouble() / duration.inMilliseconds.toDouble();
     double endT = 1.0;
@@ -69,7 +69,7 @@ class TweenList<T extends dynamic> extends Tween<T?> {
 
   ///Returns a lerped value based on theta.
   @override
-  T? lerp(double t) {
+  T lerp(double t) {
     if (t <= 0.0) {
       return _values.first.value;
     }
@@ -115,27 +115,27 @@ class TweenList<T extends dynamic> extends Tween<T?> {
 
     if (T == int) {
       return (_pair!.a.value + n * (_pair!.b.value - _pair!.a.value)).round()
-          as T?;
+          ;
     }
 
     if (T == Color) {
       return Color.lerp(_pair!.a.value as Color, _pair!.b.value as Color, n)
-          as T?;
+          as T;
     }
 
     if (T == Offset) {
       return Offset.lerp(_pair!.a.value as Offset, _pair!.b.value as Offset, n)
-          as T?;
+          as T;
     }
 
     if (T == Size) {
-      return Size.lerp(_pair!.a.value as Size, _pair!.b.value as Size, n) as T?;
+      return Size.lerp(_pair!.a.value as Size, _pair!.b.value as Size, n) as T;
     }
 
     if (T == Rect) {
-      return Rect.lerp(_pair!.a.value as Rect, _pair!.b.value as Rect, n) as T?;
+      return Rect.lerp(_pair!.a.value as Rect, _pair!.b.value as Rect, n) as T;
     }
 
-    return _pair!.a.value + n * (_pair!.b.value - _pair!.a.value) as T?;
+    return _pair!.a.value + n * (_pair!.b.value - _pair!.a.value) as T;
   }
 }

--- a/lib/widgets/attention_seekers/bounce.dart
+++ b/lib/widgets/attention_seekers/bounce.dart
@@ -53,7 +53,7 @@ class BounceAnimation extends AnimationDefinition {
     final floorCurve = Cubic(0.215, 0.61, 0.355, 1);
     final ceilCurve = Cubic(0.755, 0.05, 0.855, 0.06);
     return {
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: floorCurve),
           TweenPercentage(percent: 20, value: 0.0, curve: floorCurve),
@@ -62,7 +62,7 @@ class BounceAnimation extends AnimationDefinition {
           TweenPercentage(percent: 53, value: 0.0, curve: floorCurve),
           TweenPercentage(percent: 70, value: -15.0, curve: ceilCurve),
           TweenPercentage(percent: 80, value: 0.0, curve: floorCurve),
-          TweenPercentage(percent: 90, value: -4.0),
+          TweenPercentage(percent: 90, value: -4.0), 
           TweenPercentage(percent: 100, value: 0.0, curve: floorCurve),
         ],
       ),

--- a/lib/widgets/attention_seekers/flash.dart
+++ b/lib/widgets/attention_seekers/flash.dart
@@ -45,7 +45,7 @@ class FlashAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 25, value: 0.0),

--- a/lib/widgets/attention_seekers/head_shake.dart
+++ b/lib/widgets/attention_seekers/head_shake.dart
@@ -53,7 +53,7 @@ class HeadShakeAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Curves.easeInOut;
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 13, value: -6.0, curve: curve),
@@ -63,7 +63,7 @@ class HeadShakeAnimation extends AnimationDefinition {
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "rotateY": TweenList<double?>(
+      "rotateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 13, value: -9.0 * toRad, curve: curve),

--- a/lib/widgets/attention_seekers/heart_beat.dart
+++ b/lib/widgets/attention_seekers/heart_beat.dart
@@ -51,7 +51,7 @@ class HeartBeatAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Curves.easeInOut;
     return {
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: curve),
           TweenPercentage(percent: 14, value: 1.3, curve: curve),

--- a/lib/widgets/attention_seekers/jello.dart
+++ b/lib/widgets/attention_seekers/jello.dart
@@ -51,7 +51,7 @@ class JelloAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "transform": TweenList<double?>(
+      "transform": TweenList<double>(
         [
           TweenPercentage(percent: 11, value: 0.0),
           TweenPercentage(percent: 22, value: -12.5 * toRad),

--- a/lib/widgets/attention_seekers/rubber_band.dart
+++ b/lib/widgets/attention_seekers/rubber_band.dart
@@ -51,7 +51,7 @@ class RubberBandAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final m = Matrix4.identity();
     return {
-      "transform": TweenList<Matrix4?>(
+      "transform": TweenList<Matrix4>(
         [
           TweenPercentage(percent: 0, value: m),
           TweenPercentage(percent: 30, value: m.scaled(1.25, 0.75, 1.0)),

--- a/lib/widgets/attention_seekers/shake.dart
+++ b/lib/widgets/attention_seekers/shake.dart
@@ -54,7 +54,7 @@ class ShakeAnimation extends AnimationDefinition {
     final b = -10.0;
     final c = 10.0;
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: a),
           TweenPercentage(percent: 10, value: b),

--- a/lib/widgets/attention_seekers/swing.dart
+++ b/lib/widgets/attention_seekers/swing.dart
@@ -50,7 +50,7 @@ class SwingAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 20, value: 15.0 * toRad),

--- a/lib/widgets/attention_seekers/tada.dart
+++ b/lib/widgets/attention_seekers/tada.dart
@@ -63,7 +63,7 @@ class TadaAnimation extends AnimationDefinition {
     m40.rotate(axis, -3.0 * toRad);
 
     return {
-      "transform": TweenList<Matrix4?>(
+      "transform": TweenList<Matrix4>(
         [
           TweenPercentage(percent: 0, value: m),
           TweenPercentage(percent: 10, value: m10),

--- a/lib/widgets/attention_seekers/wobble.dart
+++ b/lib/widgets/attention_seekers/wobble.dart
@@ -73,7 +73,7 @@ class WobbleAnimation extends AnimationDefinition {
     m75.rotate(axis, -1.0 * toRad);
 
     return {
-      "transform": TweenList<Matrix4?>(
+      "transform": TweenList<Matrix4>(
         [
           TweenPercentage(percent: 0, value: m),
           TweenPercentage(percent: 15, value: m15),

--- a/lib/widgets/bouncing_entrances/bounce_in.dart
+++ b/lib/widgets/bouncing_entrances/bounce_in.dart
@@ -54,13 +54,13 @@ class BounceInAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 60, value: 1.0, curve: curve),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.3, curve: curve),
           TweenPercentage(percent: 20, value: 1.1, curve: curve),

--- a/lib/widgets/bouncing_entrances/bounce_in_down.dart
+++ b/lib/widgets/bouncing_entrances/bounce_in_down.dart
@@ -57,13 +57,13 @@ class BounceInDownAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 60, value: 1.0, curve: curve),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.height, curve: curve),
           TweenPercentage(percent: 60, value: 25.0, curve: curve),

--- a/lib/widgets/bouncing_entrances/bounce_in_left.dart
+++ b/lib/widgets/bouncing_entrances/bounce_in_left.dart
@@ -57,13 +57,13 @@ class BounceInLeftAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 60, value: 1.0, curve: curve),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.width, curve: curve),
           TweenPercentage(percent: 60, value: 25.0, curve: curve),

--- a/lib/widgets/bouncing_entrances/bounce_in_right.dart
+++ b/lib/widgets/bouncing_entrances/bounce_in_right.dart
@@ -57,13 +57,13 @@ class BounceInRightAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 60, value: 1.0, curve: curve),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.width, curve: curve),
           TweenPercentage(percent: 60, value: -25.0, curve: curve),

--- a/lib/widgets/bouncing_entrances/bounce_in_up.dart
+++ b/lib/widgets/bouncing_entrances/bounce_in_up.dart
@@ -57,13 +57,13 @@ class BounceInUpAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 60, value: 1.0, curve: curve),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.height, curve: curve),
           TweenPercentage(percent: 60, value: -25.0, curve: curve),

--- a/lib/widgets/bouncing_exits/bounce_out.dart
+++ b/lib/widgets/bouncing_exits/bounce_out.dart
@@ -55,13 +55,13 @@ class BounceOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 55, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 20, value: 0.9),

--- a/lib/widgets/bouncing_exits/bounce_out_down.dart
+++ b/lib/widgets/bouncing_exits/bounce_out_down.dart
@@ -56,13 +56,13 @@ class BounceOutDownAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 45, value: 1.0, curve: curve),
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 20, value: 10.0, curve: curve),

--- a/lib/widgets/bouncing_exits/bounce_out_left.dart
+++ b/lib/widgets/bouncing_exits/bounce_out_left.dart
@@ -56,13 +56,13 @@ class BounceOutLeftAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 45, value: 1.0, curve: curve),
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 20, value: -10.0, curve: curve),

--- a/lib/widgets/bouncing_exits/bounce_out_right.dart
+++ b/lib/widgets/bouncing_exits/bounce_out_right.dart
@@ -56,13 +56,13 @@ class BounceOutRightAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 45, value: 1.0, curve: curve),
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 20, value: 10.0, curve: curve),

--- a/lib/widgets/bouncing_exits/bounce_out_up.dart
+++ b/lib/widgets/bouncing_exits/bounce_out_up.dart
@@ -56,13 +56,13 @@ class BounceOutUpAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     final curve = Cubic(0.215, 0.61, 0.355, 1);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 45, value: 1.0, curve: curve),
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 20, value: -10.0, curve: curve),

--- a/lib/widgets/fading_entrances/fade_in.dart
+++ b/lib/widgets/fading_entrances/fade_in.dart
@@ -45,7 +45,7 @@ class FadeInAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),

--- a/lib/widgets/fading_entrances/fade_in_down.dart
+++ b/lib/widgets/fading_entrances/fade_in_down.dart
@@ -56,13 +56,13 @@ class FadeInDownAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -widgetSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_down_big.dart
+++ b/lib/widgets/fading_entrances/fade_in_down_big.dart
@@ -56,13 +56,13 @@ class FadeInDownBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_left.dart
+++ b/lib/widgets/fading_entrances/fade_in_left.dart
@@ -56,13 +56,13 @@ class FadeInLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -widgetSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_left_big.dart
+++ b/lib/widgets/fading_entrances/fade_in_left_big.dart
@@ -56,13 +56,13 @@ class FadeInLeftBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_right.dart
+++ b/lib/widgets/fading_entrances/fade_in_right.dart
@@ -56,13 +56,13 @@ class FadeInRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: widgetSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_right_big.dart
+++ b/lib/widgets/fading_entrances/fade_in_right_big.dart
@@ -56,13 +56,13 @@ class FadeInRightBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_up.dart
+++ b/lib/widgets/fading_entrances/fade_in_up.dart
@@ -56,13 +56,13 @@ class FadeInUpAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: widgetSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_entrances/fade_in_up_big.dart
+++ b/lib/widgets/fading_entrances/fade_in_up_big.dart
@@ -56,13 +56,13 @@ class FadeInUpBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_exits/fade_out.dart
+++ b/lib/widgets/fading_exits/fade_out.dart
@@ -45,7 +45,7 @@ class FadeOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/fading_exits/fade_out_down.dart
+++ b/lib/widgets/fading_exits/fade_out_down.dart
@@ -52,13 +52,13 @@ class FadeOutDownAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: widgetSize!.height),

--- a/lib/widgets/fading_exits/fade_out_down_big.dart
+++ b/lib/widgets/fading_exits/fade_out_down_big.dart
@@ -52,13 +52,13 @@ class FadeOutDownBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: screenSize!.height),

--- a/lib/widgets/fading_exits/fade_out_left.dart
+++ b/lib/widgets/fading_exits/fade_out_left.dart
@@ -52,13 +52,13 @@ class FadeOutLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -widgetSize!.width),

--- a/lib/widgets/fading_exits/fade_out_left_big.dart
+++ b/lib/widgets/fading_exits/fade_out_left_big.dart
@@ -52,13 +52,13 @@ class FadeOutLeftBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -screenSize!.width),

--- a/lib/widgets/fading_exits/fade_out_right.dart
+++ b/lib/widgets/fading_exits/fade_out_right.dart
@@ -52,13 +52,13 @@ class FadeOutRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: widgetSize!.width),

--- a/lib/widgets/fading_exits/fade_out_right_big.dart
+++ b/lib/widgets/fading_exits/fade_out_right_big.dart
@@ -52,13 +52,13 @@ class FadeOutRightBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: screenSize!.width),

--- a/lib/widgets/fading_exits/fade_out_up.dart
+++ b/lib/widgets/fading_exits/fade_out_up.dart
@@ -52,13 +52,13 @@ class FadeOutUpAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -widgetSize!.height),

--- a/lib/widgets/fading_exits/fade_out_up_big.dart
+++ b/lib/widgets/fading_exits/fade_out_up_big.dart
@@ -52,13 +52,13 @@ class FadeOutUpBigAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -screenSize!.height),

--- a/lib/widgets/flippers/flip.dart
+++ b/lib/widgets/flippers/flip.dart
@@ -56,7 +56,7 @@ class FlipAnimation extends AnimationDefinition {
     final cIn = Curves.easeIn;
     final cOut = Curves.easeOut;
     return {
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: cOut),
           TweenPercentage(percent: 40, value: 1.0, curve: cOut),
@@ -65,7 +65,7 @@ class FlipAnimation extends AnimationDefinition {
           TweenPercentage(percent: 100, value: 1.0, curve: cIn),
         ],
       ),
-      "translateZ": TweenList<double?>(
+      "translateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: cOut),
           TweenPercentage(percent: 40, value: -150.0, curve: cOut),
@@ -73,7 +73,7 @@ class FlipAnimation extends AnimationDefinition {
           TweenPercentage(percent: 80, value: 0.0, curve: cIn),
         ],
       ),
-      "rotateY": TweenList<double?>(
+      "rotateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -360.0 * toRad, curve: cOut),
           TweenPercentage(percent: 40, value: -190.0 * toRad, curve: cOut),

--- a/lib/widgets/flippers/flip_in_x.dart
+++ b/lib/widgets/flippers/flip_in_x.dart
@@ -70,13 +70,13 @@ class FlipInXAnimation extends AnimationDefinition {
       multiplier *= -1;
     }
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: Curves.easeIn),
           TweenPercentage(percent: 60, value: 1.0),
         ],
       ),
-      "rotateX": TweenList<double?>(
+      "rotateX": TweenList<double>(
         [
           TweenPercentage(
               percent: 0,

--- a/lib/widgets/flippers/flip_in_y.dart
+++ b/lib/widgets/flippers/flip_in_y.dart
@@ -54,13 +54,13 @@ class FlipInYAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: Curves.easeIn),
           TweenPercentage(percent: 60, value: 1.0),
         ],
       ),
-      "rotateY": TweenList<double?>(
+      "rotateY": TweenList<double>(
         [
           TweenPercentage(
               percent: 0, value: 90.0 * toRad, curve: Curves.easeIn),

--- a/lib/widgets/flippers/flip_out_x.dart
+++ b/lib/widgets/flippers/flip_out_x.dart
@@ -55,13 +55,13 @@ class FlipOutXAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 30, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateX": TweenList<double?>(
+      "rotateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 30, value: -20.0 * toRad),

--- a/lib/widgets/flippers/flip_out_y.dart
+++ b/lib/widgets/flippers/flip_out_y.dart
@@ -55,13 +55,13 @@ class FlipOutYAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 30, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateY": TweenList<double?>(
+      "rotateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 30, value: -20.0 * toRad),

--- a/lib/widgets/light_speed/light_speed_in.dart
+++ b/lib/widgets/light_speed/light_speed_in.dart
@@ -59,19 +59,19 @@ class LightSpeedInAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 60, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.width),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "skewX": TweenList<double?>(
+      "skewX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -30.0 * toRad),
           TweenPercentage(percent: 60, value: 20.0 * toRad),

--- a/lib/widgets/light_speed/light_speed_out.dart
+++ b/lib/widgets/light_speed/light_speed_out.dart
@@ -55,19 +55,19 @@ class LightSpeedOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 60, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: screenSize!.width),
         ],
       ),
-      "skewX": TweenList<double?>(
+      "skewX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 30.0 * toRad),

--- a/lib/widgets/rotating_entrances/rotate_in.dart
+++ b/lib/widgets/rotating_entrances/rotate_in.dart
@@ -53,13 +53,13 @@ class RotateInAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -200.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/rotating_entrances/rotate_in_down_left.dart
+++ b/lib/widgets/rotating_entrances/rotate_in_down_left.dart
@@ -53,13 +53,13 @@ class RotateInDownLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -45.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/rotating_entrances/rotate_in_down_right.dart
+++ b/lib/widgets/rotating_entrances/rotate_in_down_right.dart
@@ -53,13 +53,13 @@ class RotateInDownRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 45.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/rotating_entrances/rotate_in_up_left.dart
+++ b/lib/widgets/rotating_entrances/rotate_in_up_left.dart
@@ -53,13 +53,13 @@ class RotateInUpLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 45.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/rotating_entrances/rotate_in_up_right.dart
+++ b/lib/widgets/rotating_entrances/rotate_in_up_right.dart
@@ -53,13 +53,13 @@ class RotateInUpRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -90.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/rotating_exits/rotate_out.dart
+++ b/lib/widgets/rotating_exits/rotate_out.dart
@@ -53,13 +53,13 @@ class RotateOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -200.0 * toRad),

--- a/lib/widgets/rotating_exits/rotate_out_down_left.dart
+++ b/lib/widgets/rotating_exits/rotate_out_down_left.dart
@@ -53,13 +53,13 @@ class RotateOutDownLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 45.0 * toRad),

--- a/lib/widgets/rotating_exits/rotate_out_down_right.dart
+++ b/lib/widgets/rotating_exits/rotate_out_down_right.dart
@@ -52,13 +52,13 @@ class RotateOutDownRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -45.0 * toRad),

--- a/lib/widgets/rotating_exits/rotate_out_up_left.dart
+++ b/lib/widgets/rotating_exits/rotate_out_up_left.dart
@@ -53,13 +53,13 @@ class RotateOutUpLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -45.0 * toRad),

--- a/lib/widgets/rotating_exits/rotate_out_up_right.dart
+++ b/lib/widgets/rotating_exits/rotate_out_up_right.dart
@@ -53,13 +53,13 @@ class RotateOutUpRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 90.0 * toRad),

--- a/lib/widgets/sliding_entrances/slide_in_down.dart
+++ b/lib/widgets/sliding_entrances/slide_in_down.dart
@@ -53,7 +53,7 @@ class SlideInDownAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/sliding_entrances/slide_in_left.dart
+++ b/lib/widgets/sliding_entrances/slide_in_left.dart
@@ -53,7 +53,7 @@ class SlideInLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/sliding_entrances/slide_in_right.dart
+++ b/lib/widgets/sliding_entrances/slide_in_right.dart
@@ -53,7 +53,7 @@ class SlideInRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.width),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/sliding_entrances/slide_in_up.dart
+++ b/lib/widgets/sliding_entrances/slide_in_up.dart
@@ -53,7 +53,7 @@ class SlideInUpAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.height),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/sliding_exits/slide_out_down.dart
+++ b/lib/widgets/sliding_exits/slide_out_down.dart
@@ -49,7 +49,7 @@ class SlideOutDownAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: screenSize!.height),

--- a/lib/widgets/sliding_exits/slide_out_left.dart
+++ b/lib/widgets/sliding_exits/slide_out_left.dart
@@ -49,7 +49,7 @@ class SlideOutLeftAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -screenSize!.width),

--- a/lib/widgets/sliding_exits/slide_out_right.dart
+++ b/lib/widgets/sliding_exits/slide_out_right.dart
@@ -49,7 +49,7 @@ class SlideOutRightAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: screenSize!.width),

--- a/lib/widgets/sliding_exits/slide_out_up.dart
+++ b/lib/widgets/sliding_exits/slide_out_up.dart
@@ -49,7 +49,7 @@ class SlideOutUpAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: -screenSize!.height),

--- a/lib/widgets/slit_entrances/slit_in_diagonal.dart
+++ b/lib/widgets/slit_entrances/slit_in_diagonal.dart
@@ -38,20 +38,20 @@ class SlitInDiagonalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 1.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 800.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'rotation': TweenList<double?>(
+      'rotation': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 90.0 * toRad),
           TweenPercentage(percent: 54, value: 87.0 * toRad),

--- a/lib/widgets/slit_entrances/slit_in_horizontal.dart
+++ b/lib/widgets/slit_entrances/slit_in_horizontal.dart
@@ -35,20 +35,20 @@ class SlitInHorizontalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 1.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 800.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'rotateX': TweenList<double?>(
+      'rotateX': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -90.0 * toRad),
           TweenPercentage(percent: 54, value: -87.0 * toRad),

--- a/lib/widgets/slit_entrances/slit_in_vertical.dart
+++ b/lib/widgets/slit_entrances/slit_in_vertical.dart
@@ -35,20 +35,20 @@ class SlitInVerticalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 1.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 800.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'rotateY': TweenList<double?>(
+      'rotateY': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -90.0 * toRad),
           TweenPercentage(percent: 54, value: -87.0 * toRad),

--- a/lib/widgets/slit_exits/slit_out_diagonal.dart
+++ b/lib/widgets/slit_exits/slit_out_diagonal.dart
@@ -38,20 +38,20 @@ class SlitOutDiagonalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 54, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 800.0),
         ],
       ),
-      'rotation': TweenList<double?>(
+      'rotation': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0 * toRad),
           TweenPercentage(percent: 54, value: 87.0 * toRad),

--- a/lib/widgets/slit_exits/slit_out_horizontal.dart
+++ b/lib/widgets/slit_exits/slit_out_horizontal.dart
@@ -35,20 +35,20 @@ class SlitOutHorizontalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 54, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 800.0),
         ],
       ),
-      'rotateX': TweenList<double?>(
+      'rotateX': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0 * toRad),
           TweenPercentage(percent: 54, value: -87.0 * toRad),

--- a/lib/widgets/slit_exits/slit_out_vertical.dart
+++ b/lib/widgets/slit_exits/slit_out_vertical.dart
@@ -35,20 +35,20 @@ class SlitOutVerticalAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      'opacity': TweenList<double?>(
+      'opacity': TweenList<double>(
         [
           TweenPercentage(percent: 54, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      'translateZ': TweenList<double?>(
+      'translateZ': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 54, value: 160.0),
           TweenPercentage(percent: 100, value: 800.0),
         ],
       ),
-      'rotateY': TweenList<double?>(
+      'rotateY': TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0 * toRad),
           TweenPercentage(percent: 54, value: -87.0 * toRad),

--- a/lib/widgets/specials/cross_fade_a_b.dart
+++ b/lib/widgets/specials/cross_fade_a_b.dart
@@ -50,12 +50,12 @@ class CrossFadeABState extends State<CrossFadeAB> implements TickerProvider {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      children: <Widget?>[
+      children: <Widget>[
         animatorA == null
             ? widget.childA
             : animatorA!.build(context, widget.childA),
-        animatorB == null ? null : animatorB!.build(context, widget.childB),
-      ].where((widget) => widget != null).toList() as List<Widget>,
+        if (animatorB != null) animatorB!.build(context, widget.childB),
+      ],
     );
   }
 

--- a/lib/widgets/specials/hinge.dart
+++ b/lib/widgets/specials/hinge.dart
@@ -57,19 +57,19 @@ class HingeAnimation extends AnimationDefinition {
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     const curve = Curves.easeInOut;
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 80, value: 1.0, curve: curve),
           TweenPercentage(percent: 100, value: 0.0, curve: curve),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 80, value: 0.0, curve: curve),
           TweenPercentage(percent: 100, value: 700.0, curve: curve),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: curve),
           TweenPercentage(percent: 20, value: 80.0 * toRad, curve: curve),

--- a/lib/widgets/specials/jack_in_the_box.dart
+++ b/lib/widgets/specials/jack_in_the_box.dart
@@ -54,19 +54,19 @@ class JackInTheBoxAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.1),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 30.0 * toRad),
           TweenPercentage(percent: 50, value: -10.0 * toRad),

--- a/lib/widgets/specials/roll_in.dart
+++ b/lib/widgets/specials/roll_in.dart
@@ -59,19 +59,19 @@ class RollInAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -widgetSize!.width),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -120.0 * toRad),
           TweenPercentage(percent: 100, value: 0.0),

--- a/lib/widgets/specials/roll_out.dart
+++ b/lib/widgets/specials/roll_out.dart
@@ -55,19 +55,19 @@ class RollOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 100, value: 0.0),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: widgetSize!.width),
         ],
       ),
-      "rotateZ": TweenList<double?>(
+      "rotateZ": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 120.0 * toRad),

--- a/lib/widgets/zooming_entrances/zoom_in.dart
+++ b/lib/widgets/zooming_entrances/zoom_in.dart
@@ -52,13 +52,13 @@ class ZoomInAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0),
           TweenPercentage(percent: 100, value: 1.0),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.3),
           TweenPercentage(percent: 100, value: 1.0),

--- a/lib/widgets/zooming_entrances/zoom_in_down.dart
+++ b/lib/widgets/zooming_entrances/zoom_in_down.dart
@@ -61,20 +61,20 @@ class ZoomInDownAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 60, value: 1.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.1, curve: c0),
           TweenPercentage(percent: 60, value: 0.475, curve: c1),
           TweenPercentage(percent: 100, value: 1.0, curve: c1),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.height, curve: c0),
           TweenPercentage(percent: 60, value: 60.0, curve: c1),

--- a/lib/widgets/zooming_entrances/zoom_in_left.dart
+++ b/lib/widgets/zooming_entrances/zoom_in_left.dart
@@ -61,20 +61,20 @@ class ZoomInLeftAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 60, value: 1.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.1, curve: c0),
           TweenPercentage(percent: 60, value: 0.475, curve: c1),
           TweenPercentage(percent: 100, value: 1.0, curve: c1),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: -screenSize!.width, curve: c0),
           TweenPercentage(percent: 60, value: 60.0, curve: c1),

--- a/lib/widgets/zooming_entrances/zoom_in_right.dart
+++ b/lib/widgets/zooming_entrances/zoom_in_right.dart
@@ -61,20 +61,20 @@ class ZoomInRightAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 60, value: 1.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.1, curve: c0),
           TweenPercentage(percent: 60, value: 0.475, curve: c1),
           TweenPercentage(percent: 100, value: 1.0, curve: c1),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.width, curve: c0),
           TweenPercentage(percent: 60, value: -60.0, curve: c1),

--- a/lib/widgets/zooming_entrances/zoom_in_up.dart
+++ b/lib/widgets/zooming_entrances/zoom_in_up.dart
@@ -61,20 +61,20 @@ class ZoomInUpAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 60, value: 1.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.1, curve: c0),
           TweenPercentage(percent: 60, value: 0.475, curve: c1),
           TweenPercentage(percent: 100, value: 1.0, curve: c1),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: screenSize!.height, curve: c0),
           TweenPercentage(percent: 60, value: -60.0, curve: c1),

--- a/lib/widgets/zooming_exits/zoom_out.dart
+++ b/lib/widgets/zooming_exits/zoom_out.dart
@@ -52,13 +52,13 @@ class ZoomOutAnimation extends AnimationDefinition {
   @override
   Map<String, TweenList> getDefinition({Size? screenSize, Size? widgetSize}) {
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 50, value: 0.0),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0),
           TweenPercentage(percent: 50, value: 0.3),

--- a/lib/widgets/zooming_exits/zoom_out_down.dart
+++ b/lib/widgets/zooming_exits/zoom_out_down.dart
@@ -57,20 +57,20 @@ class ZoomOutDownAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 40, value: 1.0, curve: c0),
           TweenPercentage(percent: 100, value: 0.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: c0),
           TweenPercentage(percent: 40, value: 0.475, curve: c0),
           TweenPercentage(percent: 100, value: 0.1, curve: c1),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 40, value: -60.0, curve: c0),

--- a/lib/widgets/zooming_exits/zoom_out_left.dart
+++ b/lib/widgets/zooming_exits/zoom_out_left.dart
@@ -57,20 +57,20 @@ class ZoomOutLeftAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 40, value: 1.0, curve: c0),
           TweenPercentage(percent: 100, value: 0.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: c0),
           TweenPercentage(percent: 40, value: 0.475, curve: c0),
           TweenPercentage(percent: 100, value: 0.1, curve: c1),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 40, value: 60.0, curve: c0),

--- a/lib/widgets/zooming_exits/zoom_out_right.dart
+++ b/lib/widgets/zooming_exits/zoom_out_right.dart
@@ -57,20 +57,20 @@ class ZoomOutRightAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 40, value: 1.0, curve: c0),
           TweenPercentage(percent: 100, value: 0.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: c0),
           TweenPercentage(percent: 40, value: 0.475, curve: c0),
           TweenPercentage(percent: 100, value: 0.1, curve: c1),
         ],
       ),
-      "translateX": TweenList<double?>(
+      "translateX": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 40, value: -60.0, curve: c0),

--- a/lib/widgets/zooming_exits/zoom_out_up.dart
+++ b/lib/widgets/zooming_exits/zoom_out_up.dart
@@ -57,20 +57,20 @@ class ZoomOutUpAnimation extends AnimationDefinition {
     final c0 = Cubic(0.55, 0.55, 0.675, 0.19);
     final c1 = Cubic(0.175, 0.885, 0.32, 1.0);
     return {
-      "opacity": TweenList<double?>(
+      "opacity": TweenList<double>(
         [
           TweenPercentage(percent: 40, value: 1.0, curve: c0),
           TweenPercentage(percent: 100, value: 0.0, curve: c1),
         ],
       ),
-      "scale": TweenList<double?>(
+      "scale": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 1.0, curve: c0),
           TweenPercentage(percent: 40, value: 0.475, curve: c0),
           TweenPercentage(percent: 100, value: 0.1, curve: c1),
         ],
       ),
-      "translateY": TweenList<double?>(
+      "translateY": TweenList<double>(
         [
           TweenPercentage(percent: 0, value: 0.0, curve: c0),
           TweenPercentage(percent: 40, value: 60.0, curve: c0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
current nullsafety version not work correctly i face some issuse with like 
```
type '_AnimatedEvaluation<double?>' is not a subtype of type 'Animation<double>' in type cast
When the exception was thrown, this was the stack:
#0      FadeOutAnimation.build (package:flutter_animator/widgets/fading_exits/fade_out.dart:40:40)
```
this from offical example after migrate it

also  this 
```
RubberBand(
            child: FlatButton(onPressed: () {}, child: Text("hii")),
          )
```
will throw 
```
type 'Matrix4' is not a subtype of type 'num'
The relevant error-causing widget was:
  AnimatedBuilder
  /flutter_animator-3.1.0/lib/widgets/attention_seekers/rubber_band.dart:39:12

```
( the bugs here that type here is Matrix4? not Matrix4 so the if(T == Matrix4) give false )
__________________________
 every issuses here because of use " as " like " as List\<double>"  or 'as List\<Widget>' ( "dart migrate" do this bug a log )
__________________________
this pull request
 solve this bugs 
migrate example and demo_app to null safety ( also i test both run fine now )

