### PR TITLE
fix setState called after dispose issue

### DIFF
--- a/lib/widgets/animator_widget.dart
+++ b/lib/widgets/animator_widget.dart
@@ -103,6 +103,10 @@ class AnimatorWidgetState<T extends AnimatorWidget> extends State<T>
     if (widget.definition.needsWidgetSize ||
         widget.definition.needsScreenSize) {
       WidgetsBinding.instance!.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+
         setState(() {
           if (widget.definition.needsWidgetSize) {
             RenderBox renderBox = context.findRenderObject() as RenderBox;


### PR DESCRIPTION
Upon hot reloading, flutter throws `setState called after dispose`, as setState invocation is hooked to `addPostFrameCallback`.

**Steps to reproduce the issue:**

1. Deploy any simple animation.
2. Trigger hot reload.

**Solution:**
Check if the widget is `mounted` before proceeding.