### PR TITLE
added _ambiguate to remove error when building with Flutter 3.0

### DIFF
--- a/lib/widgets/animator_widget.dart
+++ b/lib/widgets/animator_widget.dart
@@ -94,12 +94,17 @@ class AnimatorWidgetState<T extends AnimatorWidget> extends State<T>
     return animator!.build(context, widget.child);
   }
 
+  /// This allows a value of type T or T?
+  /// to be treated as a value of type T?.
+  /// _ambiguate(WidgetsBinding.instance)? will work with Flutter 3.0 and 2.x.x
+  T? _ambiguate<T>(T? value) => value;
+
   void _createAnimator() {
     animator = Animator(vsync: this);
     animator!.setAnimationDefinition(widget.definition);
     if (widget.definition.needsWidgetSize ||
         widget.definition.needsScreenSize) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
         if (!mounted) {
           return;
         }


### PR DESCRIPTION
Remove compile warning when building with Flutter 3.0 as WidgetsBinding.instance can not be null in Flutter 3.0